### PR TITLE
use `.valueOf` instead of `.toString.call`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * toString ref.
  */
@@ -20,13 +19,11 @@ module.exports = function(val){
     case '[object RegExp]': return 'regexp';
     case '[object Arguments]': return 'arguments';
     case '[object Array]': return 'array';
-    case '[object String]': return 'string';
   }
 
   if (val === null) return 'null';
   if (val === undefined) return 'undefined';
   if (val && val.nodeType === 1) return 'element';
-  if (val === Object(val)) return 'object';
-
-  return typeof val;
+  
+  return typeof val.valueOf();
 };


### PR DESCRIPTION
> The valueOf() method returns the primitive value of the specified object.
