### PR TITLE
Falls back to Object.prototype.valueOf if it is not present on the value

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,5 +26,9 @@ module.exports = function(val){
   if (val !== val) return 'nan';
   if (val && val.nodeType === 1) return 'element';
 
-  return typeof val.valueOf();
+  val = val.valueOf
+    ? val.valueOf()
+    : Object.prototype.valueOf.apply(val)
+
+  return typeof val;
 };


### PR DESCRIPTION
example in ie8

``` js
typeof document.querySelectorAll('a').valueOf();
// ! Object doesn't support this property or method
typeof Object.prototype.valueOf.apply(document.querySelectorAll('a'))
// > "object"
```
